### PR TITLE
fix(ci): Correct Gradle setup action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: gradle
 
       - name: Set up Gradle
-        uses: gradle/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v3 # Note: v3 is the current stable version for this action
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## Description

The Diagnosis
The CI build is failing due to an incorrect reference to the Gradle setup action. The error message "Unable to resolve action gradle/setup-gradle@v4", action not found occurred as GitHub Actions cannot find a repository under the gradle organization with the name setup-gradle. This is because the official Gradle team renamed and moved their actions into a monorepo.

The Solution
The correct, current name for the action is `gradle/actions/setup-gradle`.
